### PR TITLE
_delete_swap()  TypeError if child._parent

### DIFF
--- a/binaryheap.js
+++ b/binaryheap.js
@@ -199,10 +199,12 @@ Heap.prototype._delete_swap = function(parent, child) {
   if (parent._right != child)
     child._right = parent._right;
 
-  if (child._parent._left == child)
-    child._parent._left = null;
-  else
-    child._parent._right = null;
+  if(child._parent) {
+    if (child._parent._left == child)
+      child._parent._left = null;
+    else
+      child._parent._right = null;
+  }
 
   child._parent = parent._parent;
 


### PR DESCRIPTION
In some case (using native-dns) _delete_swap() may throw TypeError 
if child._parent is null. 

Expl:

```
TypeError: Cannot read property '_left' of null
    at Heap._delete_swap (/(...)/native-dns/node_modules/binaryheap/binaryheap.js:202:20)
    at Heap.remove (/(...)/native-dns/node_modules/binaryheap/binaryheap.js:104:10)
    at MemoryStoreExpire.delete (/(...)/native-dns/lib/cache.js:106:19)
    at /(...)/native-dns/lib/memory.js:35:5
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

This minimalist patch prevent this kind of error, but it require a review: is it relevant with the rest of the code ?

Thanks !
