### PR TITLE
Define obj properties as non-enumerable

### DIFF
--- a/binaryheap.js
+++ b/binaryheap.js
@@ -33,10 +33,22 @@ var Heap = function(min) {
 };
 
 Heap.init = function(obj, key) {
-  obj._parent = null;
-  obj._left = null;
-  obj._right = null;
-  obj._key = key;
+  Object.defineProperty(obj, '_parent', {
+    value: null,
+    writable: true
+  });
+  Object.defineProperty(obj, '_left', {
+    value: null,
+    writable: true
+  });
+  Object.defineProperty(obj, '_right', {
+    value: null,
+    writable: true
+  });
+  Object.defineProperty(obj, '_key', {
+    value: key,
+    writable: true
+  });
   return obj;
 };
 


### PR DESCRIPTION
Using defineProperty() means that things like _parent won't show up when you print an object (e.g. console.log(heap.pop()) ). Just makes things a little prettier!
